### PR TITLE
fix: make source_ids schema provider-compatible

### DIFF
--- a/internal/mcpserver/passthrough_test.go
+++ b/internal/mcpserver/passthrough_test.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -118,5 +119,24 @@ func TestPassthroughFallback_NoPassthroughSources(t *testing.T) {
 	ranked := applyPassthroughFallback(ctx, stack, models.RankedResults{}, 10, nil)
 	if len(ranked.Results) != 0 {
 		t.Fatalf("expected 0, got %d", len(ranked.Results))
+	}
+}
+
+func TestSearchToolsInputSchema_SourceIDsIsArray(t *testing.T) {
+	raw, err := json.Marshal(searchToolsInputSchema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema struct {
+		Properties map[string]struct {
+			Type any `json:"type"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatal(err)
+	}
+	got := schema.Properties["source_ids"].Type
+	if got != "array" {
+		t.Fatalf("source_ids type: got %#v want %q", got, "array")
 	}
 }

--- a/internal/mcpserver/tools_search.go
+++ b/internal/mcpserver/tools_search.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"lazy-tool/internal/config"
 	"lazy-tool/internal/metrics"
@@ -51,11 +52,11 @@ type searchHit struct {
 	Score               float64            `json:"score"`
 	ScoreBreakdown      map[string]float64 `json:"score_breakdown,omitempty"`
 	WhyMatched          []string           `json:"why_matched"`
-	NextToolName        string          `json:"next_tool_name,omitempty"`
-	NextInputExample    map[string]any  `json:"next_input_example,omitempty"`
-	RequiredInputFields []string        `json:"required_input_fields,omitempty"`
-	NextStep            string          `json:"next_step,omitempty"`
-	Anthropic           *anthropicBlock `json:"anthropic,omitempty"`
+	NextToolName        string             `json:"next_tool_name,omitempty"`
+	NextInputExample    map[string]any     `json:"next_input_example,omitempty"`
+	RequiredInputFields []string           `json:"required_input_fields,omitempty"`
+	NextStep            string             `json:"next_step,omitempty"`
+	Anthropic           *anthropicBlock    `json:"anthropic,omitempty"`
 }
 
 func anthropicHint(kindStr, proxy string) *anthropicBlock {
@@ -256,10 +257,53 @@ type searchToolsOut struct {
 	Grouped       []searchGroupWire `json:"grouped,omitempty"`
 }
 
+func searchToolsInputSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"query": {
+				Type:        "string",
+				Description: "natural language query",
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "max results (default 10)",
+			},
+			"source_ids": {
+				Type:        "array",
+				Description: "filter to these upstream source ids",
+				Items:       &jsonschema.Schema{Type: "string"},
+			},
+			"group_by_source": {
+				Type:        "boolean",
+				Description: "group hits by upstream source id",
+			},
+			"lexical_only": {
+				Type:        "boolean",
+				Description: "skip embeddings and vector retrieval for this query",
+			},
+			"explain_scores": {
+				Type:        "boolean",
+				Description: "include pre-ranker score_breakdown per hit",
+			},
+		},
+		Required: []string{"query"},
+		PropertyOrder: []string{
+			"query",
+			"limit",
+			"source_ids",
+			"group_by_source",
+			"lexical_only",
+			"explain_scores",
+		},
+	}
+}
+
 func registerSearchTools(server *mcp.Server, stack *runtime.Stack) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search_tools",
 		Description: "Search the local MCP catalog: tools, prompts, and resources (lexical FTS5 + optional vector boost). Then use next_tool_name with next_input_example from a result; do not invent proxy_tool_name values.",
+		InputSchema: searchToolsInputSchema(),
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in searchToolsArgs) (*mcp.CallToolResult, searchToolsOut, error) {
 		lim := in.Limit
 		if lim <= 0 {


### PR DESCRIPTION
## Summary
- expose `search_tools.source_ids` as an optional plain array schema instead of a nullable union
- keep runtime behavior unchanged: callers can still omit `source_ids` when unused
- add a regression test that asserts the emitted schema type is `array`

## Why
The previous generated schema used `type: ["null", "array"]`. That is valid JSON Schema, but some MCP clients and provider function-declaration adapters reject nullable union types for tool parameters. Since `source_ids` is optional, it does not need to include `null` in the schema type.

This improves compatibility for clients that translate MCP tools into provider function declarations while preserving the existing optional argument behavior.

## Verification
- `go test ./internal/mcpserver -run TestSearchToolsInputSchema_SourceIDsIsArray`
- `go test ./...`